### PR TITLE
Fix Flexmax80

### DIFF
--- a/matenet/matenet.py
+++ b/matenet/matenet.py
@@ -218,7 +218,9 @@ class Mate(MateNET):
         :param port: int, 0-10 (root:0)
         :return: int, the type of device that is attached (see MateNET.DEVICE_*)
         """
-        result = self.query(0x00, port=port) & 0x00FF
+        result = self.query(0x00, port=port)
+        if result is not None:
+            result = result & 0x00FF
         return result
 
     def query(self, reg, param=0, port=0):

--- a/matenet/matenet.py
+++ b/matenet/matenet.py
@@ -218,7 +218,7 @@ class Mate(MateNET):
         :param port: int, 0-10 (root:0)
         :return: int, the type of device that is attached (see MateNET.DEVICE_*)
         """
-        result = self.query(0x00, port=port)
+        result = self.query(0x00, port=port) & 0x00FF
         return result
 
     def query(self, reg, param=0, port=0):


### PR DESCRIPTION
Some flexmax devices are returning "02 03" instead of "00 03" in response to a scan command (Issue #2). To resolve this, I'm just masking off the upper byte until I can figure out what it's for.