### PR TITLE
Implement synchronization of date/time/temperature

### DIFF
--- a/doc/protocol/MATEMaster.md
+++ b/doc/protocol/MATEMaster.md
@@ -4,13 +4,16 @@ The MATE itself periodically sends commands by itself to other devices in the sy
 
 In particular it has the following duties:
 
-- Time synchronization
+- Date / Time synchronization
+- Battery Temperature synchronization
 - FBX (Battery Recharging)
 - AGS (Automatic Generator System)
-- FN-DC Net AH charge stop feature
+- FN-DC Net AmpHours charge float feature
 
 
 If you are replacing the MATE with pyMATE, I recommend you implement the below features, or connect pyMATE as a 2nd mate.
+
+See `MateDevice.synchronize()`.
 
 ## Time / Date Synchronization ##
 
@@ -48,13 +51,12 @@ Temperature Mapping: (CC[`4000`] : DC[`00f0`])
 118 : 28C : 0076
 125 : 25C : 007d
 129 : 24C : 0081
-131/133 : 23C : 0085, 0083
+131 : 23C : 0083
+133 : 23C : 0085
 134 : 22C : 0086
 138 : 21C : 008a
 139 : 20C : 008b
+
+Approximate formula:
+DegC = Round((-0.3576 * raw_temp) + 70.1)
 ```
-
-
-## Other Notes ##
-
-I have also seen registers 4005 & 4001 written to, with what seem to be flags of some kind. (I've seen 4005=0C7F, 4005=0D3B, 4001=008F, 4001=0090)

--- a/doc/protocol/MATEMaster.md
+++ b/doc/protocol/MATEMaster.md
@@ -12,17 +12,17 @@ In particular it has the following duties:
 
 If you are replacing the MATE with pyMATE, I recommend you implement the below features, or connect pyMATE as a 2nd mate.
 
-## Time Synchronization ##
+## Time / Date Synchronization ##
 
 The registers [`4004`/`4005`] are written every 30 sec to MX/DC devices (not FX), encoded in a particular format:
 
 ```
-[4004]
+[4004] (TIME)
 Bits 15..11 : Hour (24h)
 Bits 10..5  : Minute
 Bits 4..0   : Second (*2)
 
-[4005]
+[4005] (DATE)
 Bits 15..9 : Year  (2000..2127)
 Bits 8..5  : Month (0..12)
 Bits 4..0  : Day   (0..31)
@@ -35,11 +35,26 @@ Bits 4..0  : Day   (0..31)
 Presumably this is used to synchronize the MX/DC's internal clock to the MATE, so they know when to do things like resetting counters at midnight. Without this they still seem to be able to function properly, but I imagine they would get out of sync over time.
 
 
-## Other Commands ##
+## Battery Temperature Synchronization ##
 
-The purpose of these registers is unknown, but they are seen regularly on the bus:
+Every 1 minute the MATE will read register [`4000`] from the MX/CC and forward the value to register [`4001`] for attached FX/DC devices.
+
+I believe this register contains the raw battery NTC temperature sensor value, which the DC converts to DegC.
+
+The battery temperature can be read from the DC at register [`00f0`], and reports the temperature in DegC. This register gets updated when register [`4001`] is written to.
 
 ```
-READ  4000 (CC)
-WRITE 4001 (FX/DC)   - Only seen 0000 values
+Temperature Mapping: (CC[`4000`] : DC[`00f0`])
+118 : 28C : 0076
+125 : 25C : 007d
+129 : 24C : 0081
+131/133 : 23C : 0085, 0083
+134 : 22C : 0086
+138 : 21C : 008a
+139 : 20C : 008b
 ```
+
+
+## Other Notes ##
+
+I have also seen registers 4005 & 4001 written to, with what seem to be flags of some kind. (I've seen 4005=0C7F, 4005=0D3B, 4001=008F, 4001=0090)

--- a/doc/protocol/Protocol.md
+++ b/doc/protocol/Protocol.md
@@ -98,10 +98,3 @@ If a Hub is attached, it will simply look at the first byte coming from the MATE
 I have not explored to see what happens if two MATEs are attached to a Hub.
 
 If you have multiple FX Inverters connected, I believe they synchronize using an out-of-band channel on the CAT5 cable. I have not experimented with this as I only have one FX.
-
-## Other Notes ##
-
-After analyzing captured traffic, I have seen that the MATE writes an incrementing value to register 4004. The pattern and meaning is unclear. 
-Example values: `8C78, 8C89, 8C98, 8CA9, 8CB8, 8CC9, 8CD8`
-
-I have also seen registers 4005 & 4001 written to, with what seem to be flags of some kind. (I've seen 4005=0C7F, 4005=0D3B, 4001=008F, 4001=0090)

--- a/examples/srv1/collector.py
+++ b/examples/srv1/collector.py
@@ -211,10 +211,12 @@ def synchronize():
 	Should be called every 1 minute
 	"""
 	try:
-		MateDevice.synchronize(
+		bat_temp_raw = MateDevice.synchronize(
 			master=mx, 
 			devices=(mx,fx,dc)
 		)
+
+		log.info('Battery Temperature: %s' % MateMXDevice.convert_battery_temp(bat_temp_raw))
 	except:
 		log.exception("EXCEPTION in synchronize()")
 		return

--- a/examples/srv1/collector.py
+++ b/examples/srv1/collector.py
@@ -7,7 +7,7 @@
 # (My particular system barely has enough flash space to fit Python!)
 #
 
-from pymate.matenet import MateNET, MateMXDevice, MateFXDevice, MateDCDevice
+from pymate.matenet import MateNET, MateDevice, MateMXDevice, MateFXDevice, MateDCDevice
 from time import sleep
 from datetime import datetime
 from base64 import b64encode
@@ -205,6 +205,21 @@ def collect_dc():
 		log.exception("EXCEPTION in collect_dc()")
 		return None
 
+def synchronize():
+	"""
+	Synchronize devices
+	Should be called every 1 minute
+	"""
+	try:
+		MateDevice.synchronize(
+			master=mx, 
+			devices=(mx,fx,dc)
+		)
+	except:
+		log.exception("EXCEPTION in synchronize()")
+		return
+
+
 ##### COLLECTION STARTS #####
 
 log.info("Starting collection...")
@@ -214,6 +229,7 @@ now = datetime.now()
 t_next_status = now + STATUS_INTERVAL
 t_next_fx_status = now + FXSTATUS_INTERVAL
 t_next_dc_status = now + DCSTATUS_INTERVAL
+t_next_sync = now + SYNC_INTERVAL
 
 # Calculate datetime of next logpage collection
 d = now.date()
@@ -260,6 +276,9 @@ while True:
 				if packet:
 					upload_packet(packet)
 		
+		if now >= t_next_sync:
+			t_next_sync = now + SYNC_INTERVAL
+			synchronize()
 		
 	except Exception as e:
 		# Don't terminate the program, log and keep collecting.

--- a/examples/srv1/settings.py
+++ b/examples/srv1/settings.py
@@ -5,6 +5,7 @@ SERIAL_PORT = '/dev/ttyUSB0'
 STATUS_INTERVAL = timedelta(seconds=10)
 FXSTATUS_INTERVAL = timedelta(seconds=60)
 DCSTATUS_INTERVAL = timedelta(seconds=10)
+SYNC_INTERVAL = timedelta(minutes=1)
 LOGPAGE_RETRIEVAL_TIME = time(hour=0, minute=5)  # 5 minutes past midnight (retrieves previous day)
 ENDPOINT_URL = 'http://localhost:5000/mate'
 LOGFILE = '/tmp/log/mate-collector.log'

--- a/pymate/matenet/flexnetdc.py
+++ b/pymate/matenet/flexnetdc.py
@@ -137,6 +137,8 @@ class MateDCDevice(MateDevice):
     """
     Communicate with a FLEXnet DC unit attached to the MateNET bus
     """
+    DEVICE_TYPE = MateNET.DEVICE_DC
+
     def scan(self):
         """
         Query the attached device to make sure we're communicating with an FLEXnet DC unit
@@ -144,7 +146,7 @@ class MateDCDevice(MateDevice):
         devid = super(MateDCDevice, self).scan()
         if devid == None:
             raise RuntimeError("No response from the FLEXnet DC unit")
-        if devid != MateNET.DEVICE_FLEXNETDC:
+        if devid != self.DEVICE_TYPE:
             raise RuntimeError("Attached device is not a FLEXnet DC unit! (DeviceID: %s)" % devid)
 
     def get_status(self):

--- a/pymate/matenet/fx.py
+++ b/pymate/matenet/fx.py
@@ -148,6 +148,8 @@ class MateFXDevice(MateDevice):
     """
     Communicate with an FX unit attached to the MateNET bus
     """
+    DEVICE_TYPE = MateNET.DEVICE_FX
+
     # Error bit-field
     ERROR_LOW_VAC_OUTPUT = 0x01 # Inverter could not supply enough AC voltage to meet demand
     ERROR_STACKING_ERROR = 0x02 # Communication error among stacked FX inverters (eg. 3 phase system)
@@ -210,7 +212,7 @@ class MateFXDevice(MateDevice):
         devid = super(MateFXDevice, self).scan()
         if devid == None:
             raise RuntimeError("No response from the FX unit")
-        if devid != MateNET.DEVICE_FX:
+        if devid != self.DEVICE_TYPE:
             raise RuntimeError("Attached device is not an FX unit! (DeviceID: %s)" % devid)
 
     def get_status(self):

--- a/pymate/matenet/matedevice.py
+++ b/pymate/matenet/matedevice.py
@@ -70,7 +70,7 @@ class MateDevice(object):
         This should be sent every 15 seconds.
         NOTE: not supported on FX devices.
         """
-        assert(isinstance(time, datetime.datetime))
+        assert(isinstance(dt, datetime.datetime))
         x1 = (
             ((dt.hour & 0x1F) << 11) | 
             ((dt.minute & 0x3F) << 5) | 
@@ -101,9 +101,11 @@ class MateDevice(object):
         """
         assert(all([isinstance(d, MateDevice) for d in devices]))
         assert(isinstance(master, MateDevice)) # Should be MateMXDevice
+        assert(master.DEVICE_TYPE == MateDevice.DEVICE_MX)
+        self.log.info("Synchronize")
 
         # 1. Update date & time for attached MX/DC units
-        dt = datetime.now()
+        dt = datetime.datetime.now()
         for dev in devices:
             if (dev is not None):
                 if (dev.DEVICE_TYPE in (MateDevice.DEVICE_MX, MateDevice.DEVICE_DC)):
@@ -111,7 +113,7 @@ class MateDevice(object):
 
         # 2. Update battery temperature for attached FX/DC units
         bat_temp = master.battery_temp_raw
-        self.log.info('Battery Temperature: %dC' % mx.convert_battery_temp(bat_temp))
+        #self.log.info('Battery Temperature: %s' % master.convert_battery_temp(bat_temp))
         for dev in devices:
             if (dev is not None) and (dev is not master):
                 if (dev.DEVICE_TYPE in (MateDevice.DEVICE_FX, MateDevice.DEVICE_DC)):

--- a/pymate/matenet/matedevice.py
+++ b/pymate/matenet/matedevice.py
@@ -102,7 +102,6 @@ class MateDevice(object):
         assert(all([isinstance(d, MateDevice) for d in devices]))
         assert(isinstance(master, MateDevice)) # Should be MateMXDevice
         assert(master.DEVICE_TYPE == MateDevice.DEVICE_MX)
-        self.log.info("Synchronize")
 
         # 1. Update date & time for attached MX/DC units
         dt = datetime.datetime.now()
@@ -113,11 +112,12 @@ class MateDevice(object):
 
         # 2. Update battery temperature for attached FX/DC units
         bat_temp = master.battery_temp_raw
-        #self.log.info('Battery Temperature: %s' % master.convert_battery_temp(bat_temp))
         for dev in devices:
             if (dev is not None) and (dev is not master):
                 if (dev.DEVICE_TYPE in (MateDevice.DEVICE_FX, MateDevice.DEVICE_DC)):
                     dev.update_battery_temp(bat_temp)
+
+        return bat_temp
 
 # For backwards compatibility
 # DEPRECATRED

--- a/pymate/matenet/mx.py
+++ b/pymate/matenet/mx.py
@@ -142,6 +142,8 @@ class MXLogPagePacket(object):
 
 
 class MateMXDevice(MateDevice):
+    DEVICE_TYPE = MateNET.DEVICE_MX
+
     """
     Communicate with an MX unit attached to the MateNET bus
     """
@@ -152,7 +154,7 @@ class MateMXDevice(MateDevice):
         devid = super(MateMXDevice, self).scan()
         if devid == None:
             raise RuntimeError("No response from the MX unit")
-        if devid != MateNET.DEVICE_MX:
+        if devid != self.DEVICE_TYPE:
             raise RuntimeError("Attached device is not an MX unit! (DeviceID: %s)" % devid)
 
     def get_status(self):
@@ -236,6 +238,14 @@ class MateMXDevice(MateDevice):
     @property
     def setpt_float(self):
         return Value(self.query(0x0172) / 10.0, units='V', resolution=1)
+
+    @property
+    def battery_temp_raw(self):
+        return self.query(0x4000)
+
+    @staticmethod
+    def convert_battery_temp(raw_temp):
+        return (-0.3576 * raw_temp) + 70.05
 
 # For backwards compatibility
 # DEPRECATED

--- a/pymate/matenet/mx.py
+++ b/pymate/matenet/mx.py
@@ -245,7 +245,7 @@ class MateMXDevice(MateDevice):
 
     @staticmethod
     def convert_battery_temp(raw_temp):
-        return (-0.3576 * raw_temp) + 70.05
+        return Value((-0.3576 * raw_temp) + 70.1, units='C', resolution=0)
 
 # For backwards compatibility
 # DEPRECATED


### PR DESCRIPTION
Registers 4000, 4001, 4004, 4005 are used to synchronize time, date, and battery temperature between devices.

Resolves #19 