### PR TITLE
Workaround issue when recevied serial packets are too large

### DIFF
--- a/pymate/cstruct.py
+++ b/pymate/cstruct.py
@@ -26,6 +26,8 @@ def struct(fmt, fields):
         _size = fmt.size
         _nfields = nfields
 
+        size = fmt.size
+
         def __init__(self, *args, **kwargs):
             """
             Initialize the struct's fields from the provided args.

--- a/pymate/matenet/flexnetdc.py
+++ b/pymate/matenet/flexnetdc.py
@@ -161,7 +161,7 @@ class MateDCDevice(MateDevice):
     def get_status_raw(self):
         data = ''
         for i in range(0x0A,0x0F+1):
-            resp = self.send(MateNET.TYPE_STATUS, addr=i)
+            resp = self.send(MateNET.TYPE_STATUS, addr=i, response_len=(13*6))
             if not resp:
                 return None
             data += str(resp)

--- a/pymate/matenet/fx.py
+++ b/pymate/matenet/fx.py
@@ -14,6 +14,7 @@ from . import MateDevice, MateNET
 
 class FXStatusPacket(object):
     fmt = Struct('>BBBBBBBBBhBB')
+    size = fmt.size
 
     def __init__(self, misc=None):
         self.raw = None
@@ -220,7 +221,7 @@ class MateFXDevice(MateDevice):
         Request a status packet from the inverter
         :return: A FXStatusPacket
         """
-        resp = self.send(MateNET.TYPE_STATUS, addr=1)
+        resp = self.send(MateNET.TYPE_STATUS, addr=1, response_len=FXStatusPacket.size)
         if resp:
             status = FXStatusPacket.from_buffer(resp)
             self._is_230v = status.is_230v

--- a/pymate/matenet/matedevice.py
+++ b/pymate/matenet/matedevice.py
@@ -37,8 +37,8 @@ class MateDevice(object):
     def scan(self):
         return self.matenet.scan(self.port)
 
-    def send(self, ptype, addr, param=0):
-        return self.matenet.send(ptype, addr, param=param, port=self.port)
+    def send(self, ptype, addr, param=0, response_len=None):
+        return self.matenet.send(ptype, addr, param=param, port=self.port, response_len=None)
 
     def query(self, reg, param=0):
         return self.matenet.query(reg, param=param, port=self.port)

--- a/pymate/matenet/matenet.py
+++ b/pymate/matenet/matenet.py
@@ -66,7 +66,7 @@ class MateNET(object):
 
         self.tap = tap
 
-    def send(self, ptype, addr, param=0, port=0):
+    def send(self, ptype, addr, param=0, port=0, response_len=None):
         """
         Send a MateNET packet to the bus (as if it was sent by a MATE unit) and return the response
         :param port: Port to send to, if a hub is present (0 if no hub or talking to the hub)
@@ -84,7 +84,7 @@ class MateNET(object):
                 txbuf = packet.to_buffer()
                 self.port.send(txbuf)
 
-                rxbuf = self.port.recv()
+                rxbuf = self.port.recv(response_len)
                 if not rxbuf:
                     self.log.debug('RETRY')
                     continue  # No response - try again
@@ -131,9 +131,9 @@ class MateNET(object):
         :param param: Optional parameter
         :return: The value (16-bit uint)
         """
-        resp = self.send(MateNET.TYPE_QUERY, addr=reg, param=param, port=port)
+        resp = self.send(MateNET.TYPE_QUERY, addr=reg, param=param, port=port, response_len=MateNET.QueryResponse.size)
         if resp:
-            response = MateNET.QueryResponse.from_buffer(resp[-MateNET.QueryResponse._size:])
+            response = MateNET.QueryResponse.from_buffer(resp)
             return response.value
 
     def control(self, reg, value, port=0):
@@ -144,7 +144,7 @@ class MateNET(object):
         :param port: Port (0-10)
         :return: ???
         """
-        resp = self.send(MateNET.TYPE_CONTROL, addr=reg, param=value, port=port)
+        resp = self.send(MateNET.TYPE_CONTROL, addr=reg, param=value, port=port, response_len=MateNET.QueryResponse.size)
         if resp:
             return None  # TODO: What kind of response do we get from a control packet?
 

--- a/pymate/matenet/matenet.py
+++ b/pymate/matenet/matenet.py
@@ -171,6 +171,7 @@ class MateNET(object):
         """
         result = self.query(0x00, port=port)
         if result is not None:
+            # TODO: Don't know what the upper byte is for, but it is seen on some MX units
             result = result & 0x00FF
         return result
 
@@ -209,7 +210,7 @@ class MateNET(object):
         mx = MateMXDevice(bus, port)
         """
         for i in range(0,10):
-            dtype = self.query(0x00, port=i)
+            dtype = self.scan(port=i)
             if dtype and dtype == device_type:
                 self.log.info('Found %s device at port %d',
                     MateNET.DEVICE_TYPES[dtype],

--- a/pymate/matenet/matenet.py
+++ b/pymate/matenet/matenet.py
@@ -133,7 +133,7 @@ class MateNET(object):
         """
         resp = self.send(MateNET.TYPE_QUERY, addr=reg, param=param, port=port)
         if resp:
-            response = MateNET.QueryResponse.from_buffer(resp)
+            response = MateNET.QueryResponse.from_buffer(resp[-MateNET.QueryResponse._size:])
             return response.value
 
     def control(self, reg, value, port=0):

--- a/pymate/matenet/matenet.py
+++ b/pymate/matenet/matenet.py
@@ -77,6 +77,9 @@ class MateNET(object):
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug('Send [Port%d, Type=0x%.2x, Addr=0x%.4x, Param=0x%.4x]', port, ptype, addr, param)
 
+        if response_len is not None:
+            response_len += 1 # Account for command ack byte
+
         packet = MateNET.TxPacket(port, ptype, addr, param)
         data = None
         for i in range(self.RETRY_PACKET+1):

--- a/pymate/matenet/matenet_pjon.py
+++ b/pymate/matenet/matenet_pjon.py
@@ -184,7 +184,7 @@ class MateNETPJON(object):
         self.log.info('RX TIMEOUT')
         return None
 
-    def recv(self, timeout=1.0):
+    def recv(self, expected_len=None, timeout=1.0):
         """
         Receive a packet from PJON bus
         :param timeout: seconds to wait until returning, 0 to return immediately, None to block indefinitely
@@ -261,6 +261,8 @@ class MateNETPJON(object):
 
             if len(payload) == 1:
                 raise RuntimeError("PJON error: Error returned from controller: %.2x" % (payload[0]))
+
+            # TODO: Validate payload length against expected_len
 
             return ''.join(chr(c) for c in payload) # TODO: Hacky
 

--- a/pymate/matenet/matenet_ser.py
+++ b/pymate/matenet/matenet_ser.py
@@ -165,7 +165,10 @@ class MateNETSerial(object):
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug('RX: %s', (' '.join('%.2x' % ord(c) for c in rawdata)))
 
-        if self.TRIM_LARGE_PACKETS and expected_len is not None:
-            rawdata = rawdata[-expected_len:]
+        if expected_len is not None:
+            expected_len += 2 # Account for checksum
+
+            if self.TRIM_LARGE_PACKETS and (len(rawdata) > expected_len):
+                rawdata = rawdata[-expected_len:]
 
         return MateNETSerial._parse_packet(rawdata, expected_len)

--- a/pymate/matenet/matenet_ser.py
+++ b/pymate/matenet/matenet_ser.py
@@ -57,6 +57,9 @@ class MateNETSerial(object):
         # Amount of time with no communication that signifies the end of the packet
         self.END_OF_PACKET_TIMEOUT = 0.02 # seconds
 
+        # Set to true to workaround issue where some received packets are too large
+        self.TRIM_LARGE_PACKETS = True
+
         self.supports_spacemark = supports_spacemark
         if self.supports_spacemark is None:
             self.supports_spacemark = (
@@ -97,7 +100,7 @@ class MateNETSerial(object):
         return sum(ord(c) for c in data) % 0xFFFF
 
     @staticmethod
-    def _parse_packet(data):
+    def _parse_packet(data, expected_len=None):
         """
         Parse a MATE packet, validatin the length and checksum
         :param data: Raw string data
@@ -108,6 +111,15 @@ class MateNETSerial(object):
             raise RuntimeError("Error receiving mate packet - No data received")
         if len(data) < 3:
             raise RuntimeError("Error receiving mate packet - Received packet too small (%d bytes)" % (len(data)))
+
+        if expected_len is not None:
+            if len(data) < expected_len:
+                raise RuntimeError("Error receiving mate packet - Received packet too small (%d bytes, expected %d)" % (len(data), expected_len))
+            if len(data) > expected_len:
+                if self.TRIM_LARGE_PACKETS:
+                    data = data[-expected_len:]
+                else:
+                    RuntimeError("Error receiving mate packet - Received packet too large (%d bytes, expected %d)" % (len(data), expected_len)) 
 
         # Checksum
         packet = data[0:-2]
@@ -133,7 +145,7 @@ class MateNETSerial(object):
         # Rest of the bytes have bit8 cleared (data byte)
         self._write_9b(data[1:] + footer, 0)
 
-    def recv(self, timeout=1.0):
+    def recv(self, expected_len=None, timeout=1.0):
         """
         Receive a packet from the MateNET bus, waiting if necessary
         :param timeout: seconds to wait until returning, 0 to return immediately, None to block indefinitely
@@ -156,4 +168,4 @@ class MateNETSerial(object):
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug('RX: %s', (' '.join('%.2x' % ord(c) for c in rawdata)))
 
-        return MateNETSerial._parse_packet(rawdata)
+        return MateNETSerial._parse_packet(rawdata, expected_len)

--- a/pymate/matenet/matenet_ser.py
+++ b/pymate/matenet/matenet_ser.py
@@ -165,7 +165,7 @@ class MateNETSerial(object):
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug('RX: %s', (' '.join('%.2x' % ord(c) for c in rawdata)))
 
-        if self.TRIM_LARGE_PACKETS:
+        if self.TRIM_LARGE_PACKETS and expected_len is not None:
             rawdata = rawdata[-expected_len:]
 
         return MateNETSerial._parse_packet(rawdata, expected_len)

--- a/pymate/matenet/matenet_ser.py
+++ b/pymate/matenet/matenet_ser.py
@@ -116,10 +116,7 @@ class MateNETSerial(object):
             if len(data) < expected_len:
                 raise RuntimeError("Error receiving mate packet - Received packet too small (%d bytes, expected %d)" % (len(data), expected_len))
             if len(data) > expected_len:
-                if self.TRIM_LARGE_PACKETS:
-                    data = data[-expected_len:]
-                else:
-                    RuntimeError("Error receiving mate packet - Received packet too large (%d bytes, expected %d)" % (len(data), expected_len)) 
+                RuntimeError("Error receiving mate packet - Received packet too large (%d bytes, expected %d)" % (len(data), expected_len)) 
 
         # Checksum
         packet = data[0:-2]
@@ -167,5 +164,8 @@ class MateNETSerial(object):
 
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug('RX: %s', (' '.join('%.2x' % ord(c) for c in rawdata)))
+
+        if self.TRIM_LARGE_PACKETS:
+            rawdata = rawdata[-expected_len:]
 
         return MateNETSerial._parse_packet(rawdata, expected_len)

--- a/pymate/matenet/mx.py
+++ b/pymate/matenet/mx.py
@@ -13,6 +13,7 @@ from . import MateDevice, MateNET
 
 class MXStatusPacket(object):
     fmt = Struct('>BbbbBBBBBHH')
+    size = fmt.size
 
     STATUS_SLEEPING = 0
     STATUS_FLOATING = 1
@@ -83,6 +84,7 @@ class MXStatusPacket(object):
 
 class MXLogPagePacket(object):
     fmt = Struct('>BBBBBBBBBBBBBB')
+    size = fmt.size
 
     def __init__(self):
         self.day = None
@@ -162,7 +164,7 @@ class MateMXDevice(MateDevice):
         Request a status packet from the controller
         :return: A MXStatusPacket
         """
-        resp = self.send(MateNET.TYPE_STATUS, addr=1, param=0x00)
+        resp = self.send(MateNET.TYPE_STATUS, addr=1, param=0x00, response_len=MXStatusPacket.size)
         if resp:
             return MXStatusPacket.from_buffer(resp)
 
@@ -172,7 +174,7 @@ class MateMXDevice(MateDevice):
         :param day: The day, counting backwards from today (0:Today, -1..-255)
         :return: A MXLogPagePacket
         """
-        resp = self.send(MateNET.TYPE_LOG, addr=0, param=-day)
+        resp = self.send(MateNET.TYPE_LOG, addr=0, param=-day, response_len=MXLogPagePacket.size)
         if resp:
             return MXLogPagePacket.from_buffer(resp)
 


### PR DESCRIPTION
Adds a workaround to trim the front off any packets that are larger than expected. This should help in the case the start of the packet was not correctly found.

To turn off the workaround, specify `ser.TRIM_LARGE_PACKETS = False` where `ser` is `MateNETSerial`.

This does not apply when using the PJON transport.

Also adds packet length checking for known packet types, for robustness.

Resolves #22